### PR TITLE
Better handling of connection errors on the client.

### DIFF
--- a/src/bin/client/doomreadr.rs
+++ b/src/bin/client/doomreadr.rs
@@ -29,7 +29,7 @@ fn check_for_commands(doom: &mut Doomreadr) -> Result<(), String> {
             headers::SERVER_PAUSE => pause_play(doom, &header)?,
             headers::SERVER_GET_STATUS => get_status(doom, &header)?,
             // TODO: skip maybe? idk
-            _ => println!("Didn't understand action: {}", header.action)
+            _ => return Err(format!("Didn't understand action. Reconnecting. Action: {}", header.action))
         }
     } else {
         // NOOP
@@ -136,11 +136,19 @@ impl Doomreadr {
         loop {
             match check_for_commands(self) {
                 Ok(_) => (),
-                Err(message) => println!("{}", message)
+                Err(message) => {
+                    // Just return on all errors. We'll reconnect anyway
+                    println!("{}", message);
+                    return;
+                }
             }
             match maybe_heartbeat(self) {
                 Ok(_) => (),
-                Err(message) => println!("{}", message)
+                Err(message) => {
+                    // Just return on all errors. We'll reconnect anyway
+                    println!("{}", message);
+                    return;
+                }
             }
             self.player.maybe_enquque_song();
         }

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -1,6 +1,7 @@
 mod doomreadr;
 mod player;
 
+use std::{thread, time};
 use std::net::TcpStream;
 use std::time::Duration;
 
@@ -8,16 +9,27 @@ use doomrakr::con::Connection;
 
 use doomreadr::Doomreadr;
 
+fn handle(stream: TcpStream, client_id: &mut String) {
+    println!("Successfully connected to server in port 6142");
+
+    stream.set_read_timeout(Some(Duration::from_millis(500)))
+        .expect("Couldn't set read timeout");
+
+    let mut doom = Doomreadr::new(client_id.trim().to_string(), Connection::new(stream));
+    doom.run();
+}
+
 fn main() {
     let mut client_id = String::new();
     // May make sense to let the conneciton handle this
     std::io::stdin().read_line(&mut client_id).unwrap();
-    let stream = TcpStream::connect("localhost:6142").unwrap();
-    println!("Successfully connected to server in port 6142");
 
-    stream.set_read_timeout(Some(Duration::from_millis(500)))
-            .expect("Couldn't set read timeout");
-
-    let mut doom = Doomreadr::new(client_id.trim().to_string(), Connection::new(stream));
-    doom.run();
+    loop {
+        match TcpStream::connect("localhost:6142") {
+            Ok(stream) => handle(stream, &mut client_id),
+            Err(err) => println!("{}", err)
+        };
+        println!("Connection ended. Sleeping...");
+        thread::sleep(time::Duration::from_millis(5000));
+    }
 }


### PR DESCRIPTION
2 changes here to better handle issues here.

1. When there's an error with the connection any where (including bad
   data from the server), just close the connection and reconnect. This
   forces the server to actually send correct messages too.

2. Automatically reconnect after the disconnects above.

This is for issue #1 