### PR TITLE
Don't assume usize is always 8 bytes

### DIFF
--- a/src/bin/server/doomrakr_worker.rs
+++ b/src/bin/server/doomrakr_worker.rs
@@ -4,6 +4,7 @@ use std::ops::DerefMut;
 use std::{thread, time};
 use std::option::Option;
 use std::fs::File;
+use std::mem;
 
 use doomrakr::headers;
 use doomrakr::headers::Header;
@@ -193,7 +194,7 @@ impl DoomrakrWorker {
         }
 
         // First read 2 usize that represent paused and number of songs
-        let mut buf = [0 as u8; 8];
+        let mut buf = [0 as u8; mem::size_of::<usize>()];
         // Read if is paused
         self.con.get(&mut buf)?;
         let is_paused = usize::from_be_bytes(buf);

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,5 @@
 use crate::con::{Connection, ConnectionSend, ConnectionGet};
+use std::mem;
 
 // ACTIONS
 pub const CLIENT_HELLO: u8 = 0;
@@ -45,7 +46,7 @@ impl ConnectionSend for Header {
 impl ConnectionGet for Header {
     fn get(con: &mut Connection) -> Result<Self, String> {
         let mut action = [0 as u8; 1];
-        let mut length = [0 as u8; 8];
+        let mut length = [0 as u8; mem::size_of::<usize>()];
 
         // TODO check that the right amount of bytes were read
         con.get(&mut action)?;

--- a/src/song.rs
+++ b/src/song.rs
@@ -1,4 +1,5 @@
 use crate::con::{Connection, ConnectionSend, ConnectionGet};
+use std::mem;
 
 #[derive(Clone)]
 pub struct Song {
@@ -23,7 +24,7 @@ impl Song {
 
 impl ConnectionGet for Song {
     fn get(con: &mut Connection) -> Result<Self, String> where Self: Sized {
-        let mut length = [0 as u8; 8];
+        let mut length = [0 as u8; mem::size_of::<usize>()];
         // Read lenghts of song names
         con.get(&mut length)?;
         let artist_length = usize::from_be_bytes(length);


### PR DESCRIPTION
Fix for #13 . Was run on a raspberry pi

```
pi@raspberrypi:~/doomrakr/src $ cargo build
   Compiling doomrakr v0.1.0 (/home/pi/doomrakr)
    Finished dev [unoptimized + debuginfo] target(s) in 16.85s
```